### PR TITLE
Add meeting room booking plugin skeleton

### DIFF
--- a/wp-content/plugins/meeting-room-booking/admin/class-mrb-admin.php
+++ b/wp-content/plugins/meeting-room-booking/admin/class-mrb-admin.php
@@ -1,0 +1,21 @@
+<?php
+class MRB_Admin {
+    public function __construct() {
+        add_action( 'admin_menu', array( $this, 'register_menu' ) );
+    }
+
+    public function register_menu() {
+        add_menu_page(
+            __( 'Meeting Rooms', 'mrb' ),
+            __( 'Meeting Rooms', 'mrb' ),
+            'manage_options',
+            'mrb-dashboard',
+            array( $this, 'render_dashboard' ),
+            'dashicons-building'
+        );
+    }
+
+    public function render_dashboard() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Meeting Room Booking', 'mrb' ) . '</h1></div>';
+    }
+}

--- a/wp-content/plugins/meeting-room-booking/admin/css/admin-style.css
+++ b/wp-content/plugins/meeting-room-booking/admin/css/admin-style.css
@@ -1,0 +1,1 @@
+/* admin style placeholder */

--- a/wp-content/plugins/meeting-room-booking/admin/js/admin-script.js
+++ b/wp-content/plugins/meeting-room-booking/admin/js/admin-script.js
@@ -1,0 +1,3 @@
+(function($){
+    // admin script placeholder
+})(jQuery);

--- a/wp-content/plugins/meeting-room-booking/admin/partials/admin-dashboard.php
+++ b/wp-content/plugins/meeting-room-booking/admin/partials/admin-dashboard.php
@@ -1,0 +1,3 @@
+<div class="wrap">
+    <h1><?php esc_html_e('Meeting Room Dashboard','mrb'); ?></h1>
+</div>

--- a/wp-content/plugins/meeting-room-booking/admin/partials/reports.php
+++ b/wp-content/plugins/meeting-room-booking/admin/partials/reports.php
@@ -1,0 +1,1 @@
+<p><?php esc_html_e('Reports Placeholder','mrb'); ?></p>

--- a/wp-content/plugins/meeting-room-booking/admin/partials/system-control.php
+++ b/wp-content/plugins/meeting-room-booking/admin/partials/system-control.php
@@ -1,0 +1,1 @@
+<p><?php esc_html_e('System Control Placeholder','mrb'); ?></p>

--- a/wp-content/plugins/meeting-room-booking/admin/partials/user-management.php
+++ b/wp-content/plugins/meeting-room-booking/admin/partials/user-management.php
@@ -1,0 +1,1 @@
+<p><?php esc_html_e('User Management Placeholder','mrb'); ?></p>

--- a/wp-content/plugins/meeting-room-booking/api/class-mrb-rest-api.php
+++ b/wp-content/plugins/meeting-room-booking/api/class-mrb-rest-api.php
@@ -1,0 +1,13 @@
+<?php
+class MRB_REST_API {
+    public function register_routes() {
+        register_rest_route( 'mrb/v1', '/rooms', array(
+            'methods'  => 'GET',
+            'callback' => array( $this, 'get_rooms' ),
+        ) );
+    }
+
+    public function get_rooms( $request ) {
+        return rest_ensure_response( array() );
+    }
+}

--- a/wp-content/plugins/meeting-room-booking/api/endpoints/bookings.php
+++ b/wp-content/plugins/meeting-room-booking/api/endpoints/bookings.php
@@ -1,0 +1,4 @@
+<?php
+function mrb_api_bookings( $request ) {
+    return rest_ensure_response( array() );
+}

--- a/wp-content/plugins/meeting-room-booking/api/endpoints/reports.php
+++ b/wp-content/plugins/meeting-room-booking/api/endpoints/reports.php
@@ -1,0 +1,4 @@
+<?php
+function mrb_api_reports( $request ) {
+    return rest_ensure_response( array() );
+}

--- a/wp-content/plugins/meeting-room-booking/api/endpoints/rooms.php
+++ b/wp-content/plugins/meeting-room-booking/api/endpoints/rooms.php
@@ -1,0 +1,4 @@
+<?php
+function mrb_api_rooms( $request ) {
+    return rest_ensure_response( array() );
+}

--- a/wp-content/plugins/meeting-room-booking/api/endpoints/users.php
+++ b/wp-content/plugins/meeting-room-booking/api/endpoints/users.php
@@ -1,0 +1,4 @@
+<?php
+function mrb_api_users( $request ) {
+    return rest_ensure_response( array() );
+}

--- a/wp-content/plugins/meeting-room-booking/api/middleware/auth-middleware.php
+++ b/wp-content/plugins/meeting-room-booking/api/middleware/auth-middleware.php
@@ -1,0 +1,4 @@
+<?php
+function mrb_api_auth_middleware() {
+    return true; // placeholder
+}

--- a/wp-content/plugins/meeting-room-booking/api/middleware/rate-limit.php
+++ b/wp-content/plugins/meeting-room-booking/api/middleware/rate-limit.php
@@ -1,0 +1,4 @@
+<?php
+function mrb_api_rate_limit() {
+    return true; // placeholder
+}

--- a/wp-content/plugins/meeting-room-booking/assets/css/external-libs.css
+++ b/wp-content/plugins/meeting-room-booking/assets/css/external-libs.css
@@ -1,0 +1,1 @@
+/* external libs placeholder */

--- a/wp-content/plugins/meeting-room-booking/assets/js/external-libs.js
+++ b/wp-content/plugins/meeting-room-booking/assets/js/external-libs.js
@@ -1,0 +1,1 @@
+// external libs placeholder

--- a/wp-content/plugins/meeting-room-booking/includes/class-mrb-activator.php
+++ b/wp-content/plugins/meeting-room-booking/includes/class-mrb-activator.php
@@ -1,0 +1,6 @@
+<?php
+class MRB_Activator {
+    public static function activate() {
+        // Actions on plugin activation.
+    }
+}

--- a/wp-content/plugins/meeting-room-booking/includes/class-mrb-database.php
+++ b/wp-content/plugins/meeting-room-booking/includes/class-mrb-database.php
@@ -1,0 +1,21 @@
+<?php
+class MRB_Database {
+    private $version = '0.1.0';
+    private $tables = array('mrb_rooms');
+
+    public function maybe_create_tables() {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $charset_collate = $wpdb->get_charset_collate();
+
+        $sql = "CREATE TABLE {$wpdb->prefix}mrb_rooms (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            name varchar(100) NOT NULL,
+            capacity int NOT NULL,
+            PRIMARY KEY  (id)
+        ) $charset_collate;";
+
+        dbDelta( $sql );
+    }
+}

--- a/wp-content/plugins/meeting-room-booking/includes/class-mrb-deactivator.php
+++ b/wp-content/plugins/meeting-room-booking/includes/class-mrb-deactivator.php
@@ -1,0 +1,6 @@
+<?php
+class MRB_Deactivator {
+    public static function deactivate() {
+        // Actions on plugin deactivation.
+    }
+}

--- a/wp-content/plugins/meeting-room-booking/languages/meeting-room-booking-en.po
+++ b/wp-content/plugins/meeting-room-booking/languages/meeting-room-booking-en.po
@@ -1,0 +1,1 @@
+# English translations placeholder

--- a/wp-content/plugins/meeting-room-booking/languages/meeting-room-booking-th.po
+++ b/wp-content/plugins/meeting-room-booking/languages/meeting-room-booking-th.po
@@ -1,0 +1,1 @@
+# Thai translations placeholder

--- a/wp-content/plugins/meeting-room-booking/meeting-room-booking.php
+++ b/wp-content/plugins/meeting-room-booking/meeting-room-booking.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Plugin Name: Meeting Room Booking
+ * Description: Basic meeting room booking system.
+ * Version: 0.1.0
+ * Author: Example Author
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-mrb-activator.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-mrb-deactivator.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-mrb-database.php';
+require_once plugin_dir_path( __FILE__ ) . 'public/class-mrb-public.php';
+require_once plugin_dir_path( __FILE__ ) . 'admin/class-mrb-admin.php';
+
+function mrb_activate() {
+    \MRB_Activator::activate();
+}
+
+function mrb_deactivate() {
+    \MRB_Deactivator::deactivate();
+}
+
+register_activation_hook( __FILE__, 'mrb_activate' );
+register_deactivation_hook( __FILE__, 'mrb_deactivate' );
+
+function mrb_init() {
+    $database = new \MRB_Database();
+    $database->maybe_create_tables();
+
+    if ( is_admin() ) {
+        new \MRB_Admin();
+    } else {
+        new \MRB_Public();
+    }
+}
+add_action( 'plugins_loaded', 'mrb_init' );

--- a/wp-content/plugins/meeting-room-booking/models/class-beverage.php
+++ b/wp-content/plugins/meeting-room-booking/models/class-beverage.php
@@ -1,0 +1,5 @@
+<?php
+class MRB_Beverage {
+    public $id;
+    public $name;
+}

--- a/wp-content/plugins/meeting-room-booking/models/class-booking.php
+++ b/wp-content/plugins/meeting-room-booking/models/class-booking.php
@@ -1,0 +1,8 @@
+<?php
+class MRB_Booking_Model {
+    public $id;
+    public $room_id;
+    public $user_id;
+    public $start_time;
+    public $end_time;
+}

--- a/wp-content/plugins/meeting-room-booking/models/class-department.php
+++ b/wp-content/plugins/meeting-room-booking/models/class-department.php
@@ -1,0 +1,5 @@
+<?php
+class MRB_Department {
+    public $id;
+    public $name;
+}

--- a/wp-content/plugins/meeting-room-booking/models/class-equipment.php
+++ b/wp-content/plugins/meeting-room-booking/models/class-equipment.php
@@ -1,0 +1,5 @@
+<?php
+class MRB_Equipment {
+    public $id;
+    public $name;
+}

--- a/wp-content/plugins/meeting-room-booking/models/class-room.php
+++ b/wp-content/plugins/meeting-room-booking/models/class-room.php
@@ -1,0 +1,6 @@
+<?php
+class MRB_Room {
+    public $id;
+    public $name;
+    public $capacity;
+}

--- a/wp-content/plugins/meeting-room-booking/models/class-snack.php
+++ b/wp-content/plugins/meeting-room-booking/models/class-snack.php
@@ -1,0 +1,5 @@
+<?php
+class MRB_Snack {
+    public $id;
+    public $name;
+}

--- a/wp-content/plugins/meeting-room-booking/models/class-user.php
+++ b/wp-content/plugins/meeting-room-booking/models/class-user.php
@@ -1,0 +1,6 @@
+<?php
+class MRB_User {
+    public $id;
+    public $name;
+    public $department_id;
+}

--- a/wp-content/plugins/meeting-room-booking/public/class-mrb-booking.php
+++ b/wp-content/plugins/meeting-room-booking/public/class-mrb-booking.php
@@ -1,0 +1,8 @@
+<?php
+class MRB_Booking {
+    public function create_booking( $data ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'mrb_bookings';
+        $wpdb->insert( $table, $data );
+    }
+}

--- a/wp-content/plugins/meeting-room-booking/public/class-mrb-calendar.php
+++ b/wp-content/plugins/meeting-room-booking/public/class-mrb-calendar.php
@@ -1,0 +1,7 @@
+<?php
+class MRB_Calendar {
+    public function get_events() {
+        // Return calendar events placeholder
+        return array();
+    }
+}

--- a/wp-content/plugins/meeting-room-booking/public/class-mrb-public.php
+++ b/wp-content/plugins/meeting-room-booking/public/class-mrb-public.php
@@ -1,0 +1,12 @@
+<?php
+class MRB_Public {
+    public function __construct() {
+        add_shortcode( 'mrb_booking_form', array( $this, 'booking_form' ) );
+    }
+
+    public function booking_form() {
+        ob_start();
+        include plugin_dir_path( __FILE__ ) . 'partials/booking-form.php';
+        return ob_get_clean();
+    }
+}

--- a/wp-content/plugins/meeting-room-booking/public/css/public-style.css
+++ b/wp-content/plugins/meeting-room-booking/public/css/public-style.css
@@ -1,0 +1,1 @@
+/* public style placeholder */

--- a/wp-content/plugins/meeting-room-booking/public/css/responsive.css
+++ b/wp-content/plugins/meeting-room-booking/public/css/responsive.css
@@ -1,0 +1,1 @@
+/* responsive style placeholder */

--- a/wp-content/plugins/meeting-room-booking/public/js/booking.js
+++ b/wp-content/plugins/meeting-room-booking/public/js/booking.js
@@ -1,0 +1,1 @@
+// Booking script placeholder

--- a/wp-content/plugins/meeting-room-booking/public/js/calendar.js
+++ b/wp-content/plugins/meeting-room-booking/public/js/calendar.js
@@ -1,0 +1,1 @@
+// Calendar script placeholder

--- a/wp-content/plugins/meeting-room-booking/public/js/real-time.js
+++ b/wp-content/plugins/meeting-room-booking/public/js/real-time.js
@@ -1,0 +1,1 @@
+// Real-time updates script placeholder

--- a/wp-content/plugins/meeting-room-booking/public/js/search.js
+++ b/wp-content/plugins/meeting-room-booking/public/js/search.js
@@ -1,0 +1,1 @@
+// Search script placeholder

--- a/wp-content/plugins/meeting-room-booking/public/partials/booking-form.php
+++ b/wp-content/plugins/meeting-room-booking/public/partials/booking-form.php
@@ -1,0 +1,5 @@
+<form method="post">
+    <label><?php esc_html_e('Room','mrb'); ?> <input type="text" name="room"></label>
+    <label><?php esc_html_e('Date','mrb'); ?> <input type="date" name="date"></label>
+    <button type="submit"><?php esc_html_e('Book','mrb'); ?></button>
+</form>

--- a/wp-content/plugins/meeting-room-booking/public/partials/change-password.php
+++ b/wp-content/plugins/meeting-room-booking/public/partials/change-password.php
@@ -1,0 +1,4 @@
+<form method="post">
+    <label><?php esc_html_e('New Password','mrb'); ?> <input type="password" name="new_password"></label>
+    <button type="submit"><?php esc_html_e('Change Password','mrb'); ?></button>
+</form>

--- a/wp-content/plugins/meeting-room-booking/public/partials/check-status.php
+++ b/wp-content/plugins/meeting-room-booking/public/partials/check-status.php
@@ -1,0 +1,1 @@
+<p><?php esc_html_e('Check Status Placeholder','mrb'); ?></p>

--- a/wp-content/plugins/meeting-room-booking/public/partials/login-form.php
+++ b/wp-content/plugins/meeting-room-booking/public/partials/login-form.php
@@ -1,0 +1,5 @@
+<form method="post">
+    <label><?php esc_html_e('Username','mrb'); ?> <input type="text" name="username"></label>
+    <label><?php esc_html_e('Password','mrb'); ?> <input type="password" name="password"></label>
+    <button type="submit"><?php esc_html_e('Login','mrb'); ?></button>
+</form>

--- a/wp-content/plugins/meeting-room-booking/public/partials/main-dashboard.php
+++ b/wp-content/plugins/meeting-room-booking/public/partials/main-dashboard.php
@@ -1,0 +1,1 @@
+<h2><?php esc_html_e('Main Dashboard','mrb'); ?></h2>

--- a/wp-content/plugins/meeting-room-booking/public/partials/room-display.php
+++ b/wp-content/plugins/meeting-room-booking/public/partials/room-display.php
@@ -1,0 +1,1 @@
+<p><?php esc_html_e('Room Display Placeholder','mrb'); ?></p>

--- a/wp-content/plugins/meeting-room-booking/public/partials/work-operations.php
+++ b/wp-content/plugins/meeting-room-booking/public/partials/work-operations.php
@@ -1,0 +1,1 @@
+<p><?php esc_html_e('Work Operations Placeholder','mrb'); ?></p>


### PR DESCRIPTION
## Summary
- set up folder structure for Meeting Room Booking WordPress plugin
- add main plugin bootstrap
- add basic activation and database classes
- stub admin UI and public templates
- include API skeleton and models

## Testing
- `php -l wp-content/plugins/meeting-room-booking/meeting-room-booking.php`
- `find wp-content/plugins/meeting-room-booking -name '*.php' -print0 | xargs -0 -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_688990312f3c8326a540c8e4d9f22828